### PR TITLE
Update SuggestedBoards.md

### DIFF
--- a/windows-iotcore/learn-about-hardware/SuggestedBoards.md
+++ b/windows-iotcore/learn-about-hardware/SuggestedBoards.md
@@ -72,7 +72,6 @@ While Microsoft has engineered support for IoT Core with specific SoCs that enab
 |-------------|----------|---------|---------|
 | [Banana Pi M64](http://www.banana-pi.org/m64.html) | [Allwinner A64](http://www.allwinnertech.com/index.php?c=product&a=index&id=9) | [Get started tutorial](http://forum.banana-pi.org/c/BPI-M64/Win-10-IoT) | [Email](mailto:jasonye@banana-pi.com) |
 | [Pine 64](https://www.pine64.org/) | [Allwinner A64](http://www.allwinnertech.com/index.php?c=product&a=index&id=9) | [Download image](http://files.pine64.org/os/win10-iot/Windows10IoT_Pine64.ffu) | [Email](mailto:support@pine64.org) |
-| [Toradex Colibri T30](https://www.toradex.com/windows-iot-starter-kit) | [Nvidia Tegra 3](http://www.nvidia.com/object/tegra-3-processor.html) |[Get started tutorial](http://developer.toradex.com/knowledge-base/flashing-windows-10-iot-core) | [Email](mailto:support.arm@toradex.com) |
 
 ## Retired Devices
 This is a list of boards that we no longer provide an FFU for, though the hardware will still work with IoT Core and the SoCs on these boards are still supported. For any questions or concerns, please open an issue on GitHub.


### PR DESCRIPTION
Toradex stopped to put any effort into Windows 10 IoT Core until it sees a clear strategy and commitment from the involved companies.
http://developer.toradex.com/knowledge-base/toradex-windows-10-iot-core-pro-strategy
additionally 14393 is the last available build
