### PR TITLE
Updating Windows 10 IoT Core Packages link

### DIFF
--- a/windows-iotcore/secure-your-device/UnifiedWriteFilter.md
+++ b/windows-iotcore/secure-your-device/UnifiedWriteFilter.md
@@ -14,7 +14,7 @@ The Unified Write Filter (UWF) is a feature to protect physical storage media fr
 
 Read [Unified Write Filter](https://docs.microsoft.com/windows-hardware/customize/enterprise/unified-write-filter) for more information.
 
-If you do not have IoT Core Kits yet, download and install [Windows 10 IoT Core Packages](https://www.microsoft.com/software-download/windows10iotcore).
+If you do not have IoT Core Kits yet, download and install [Windows 10 IoT Core Packages](https://www.microsoft.com/en-us/download/details.aspx?id=55031).
 
 ## How to Install UWF on a device running Windows 10 IoT Core
 


### PR DESCRIPTION
Updating the link to Windows 10 IoT Core Packages download page. The current one is no longer valid.