### PR TITLE
Update the firmware information for Minnow Board

### DIFF
--- a/windows-iotcore/release-notes/Insider/17083.md
+++ b/windows-iotcore/release-notes/Insider/17083.md
@@ -152,7 +152,7 @@ A graphics driver to enable hardware acceleration is not included in the Joule i
 
 ### For MinnowBoard
 #### Minnowboard Max Boot and Firmware Update 
-The MinnowBoard Max will not boot unless the firmware is version .092 or later. The minimum recommended version of the firmware is “MinnowBoard MAX 0.92 32-Bit”. Firmware updates can be downloaded from [here](http://go.microsoft.com/fwlink/?LinkId=708613).
+The MinnowBoard Max will not boot unless the firmware is version .092 or later. The minimum recommended version of the firmware is “MinnowBoard MAX 0.92 64-Bit”. Firmware updates can be downloaded from [here](https://firmware.intel.com/projects/minnowboard-max).
 
 #### Minnow Board Peripheral Support
 The Windows 10 IoT Core image included in this drop supports the peripherals that are exposed on the MinnowBoard MAX board. Subsequently, Intel&reg; will provide support of the full feature set of the Baytrail processors including the Intel Celeron&trade; Processors J1900/N2930/N2807 and Intel Atom&trade; Processors E38XX.


### PR DESCRIPTION
I deploy 64-bit firmware to Minnow Board and  install Windows 10 IoT Core for Minnow Baord successfully for FallCreatesUpdates.
And the URL for firmware information for Minnow Board is bad.