### PR TITLE
Fixed MD typo in link to Device Management Client Repo

### DIFF
--- a/windows-iotcore/connect-to-cloud/ManageDevices.md
+++ b/windows-iotcore/connect-to-cloud/ManageDevices.md
@@ -28,4 +28,4 @@ A complete solution requires the following:
 * A Portal or an Application that will be used by the operator to configure and query the devices remotely.
   * This must be customized for devices by the device OEM or operator. As part of this solution, we also provide an open source data model and sample implementation for easier interaction with the IoT Hub storage and the Windows IoT client.
 
-To learn more about device management for Windows devices, visit the main [Device Management Client repo])https://github.com/ms-iot/iot-core-azure-dm-client/tree/master).
+To learn more about device management for Windows devices, visit the main [Device Management Client repo](https://github.com/ms-iot/iot-core-azure-dm-client/tree/master).


### PR DESCRIPTION
The link to the Device Management Client Repo had an MD (markdown) typo. Specifically, the link should have the form [visible-description](URL). The left-paren '(' was incorrectly a right paren ')', causing the link to fail to render correctly.  The fix is to simply replace the incorrect right-paren with the correct left-paren.