### PR TITLE
Fix Typo on release notes for Serial Port Access

### DIFF
--- a/windows-iotcore/release-notes/Insider/16257.md
+++ b/windows-iotcore/release-notes/Insider/16257.md
@@ -92,7 +92,8 @@ The Raspberry Pi3 built-in Bluetooth driver only supports low bandwidth devices 
 
 #### Serial Port Usage and Access on RPi2 
 Raspberry Pi 2 supports the serial transport for communication through the PL011 UART.  This is set by default in kernel debugging scenarios.  An application or device driver can use the PL011 UART to send and receive data with the PL011 device driver turning off the debugger using the following command:
-bcedit /set debug off 
+`bcdedit /set debug off`
+(eg. In Windows Device Portal/Processes/Run command, "c:\windows\system32\bcdedit /set debug off")
 
 #### Data breakpoints have been disabled on the Raspberry Pi2
 No workaround at this time.

--- a/windows-iotcore/release-notes/Insider/16267.md
+++ b/windows-iotcore/release-notes/Insider/16267.md
@@ -94,7 +94,9 @@ The Raspberry Pi3 built-in Bluetooth driver only supports low bandwidth devices 
 
 #### Serial Port Usage and Access on RPi2 
 Raspberry Pi 2 supports the serial transport for communication through the PL011 UART.  This is set by default in kernel debugging scenarios.  An application or device driver can use the PL011 UART to send and receive data with the PL011 device driver turning off the debugger using the following command:
-bcedit /set debug off 
+`bcdedit /set debug off`
+(eg. In Windows Device Portal/Processes/Run command, "c:\windows\system32\bcdedit /set debug off")
+
 
 #### Data breakpoints have been disabled on the Raspberry Pi2
 No workaround at this time.

--- a/windows-iotcore/release-notes/Insider/17083.md
+++ b/windows-iotcore/release-notes/Insider/17083.md
@@ -98,10 +98,9 @@ The Raspberry Pi3 built-in Bluetooth driver only supports low bandwidth devices 
 
 #### Serial Port Usage and Access on RPi2 
 Raspberry Pi 2 supports the serial transport for communication through the PL011 UART.  This is set by default in kernel debugging scenarios.  An application or device driver can use the PL011 UART to send and receive data with the PL011 device driver turning off the debugger using the following command:
+`bcdedit /set debug off`
+(eg. In Windows Device Portal/Processes/Run command, "c:\windows\system32\bcdedit /set debug off")
 
-```
-bcedit /set debug off 
-```
 
 #### Data breakpoints have been disabled on the Raspberry Pi2
 No workaround at this time.

--- a/windows-iotcore/release-notes/Insider/17110.md
+++ b/windows-iotcore/release-notes/Insider/17110.md
@@ -96,7 +96,9 @@ The Raspberry Pi3 built-in Bluetooth driver only supports low bandwidth devices 
 
 #### Serial Port Usage and Access on RPi2 
 Raspberry Pi 2 supports the serial transport for communication through the PL011 UART.  This is set by default in kernel debugging scenarios.  An application or device driver can use the PL011 UART to send and receive data with the PL011 device driver turning off the debugger using the following command:
-bcedit /set debug off 
+`bcdedit /set debug off`
+(eg. In Windows Device Portal/Processes/Run command, "c:\windows\system32\bcdedit /set debug off")
+
 
 #### Data breakpoints have been disabled on the Raspberry Pi2
 No workaround at this time.

--- a/windows-iotcore/release-notes/Insider/17661.md
+++ b/windows-iotcore/release-notes/Insider/17661.md
@@ -62,9 +62,9 @@ The Raspberry Pi3 built-in Bluetooth driver only supports low bandwidth devices 
 
 #### Serial Port Usage and Access on RPi2 
 Raspberry Pi 2 supports the serial transport for communication through the PL011 UART.  This is set by default in kernel debugging scenarios.  An application or device driver can use the PL011 UART to send and receive data with the PL011 device driver turning off the debugger using the following command:
-```
-bcedit /set debug off 
-```
+`bcdedit /set debug off`
+(eg. In Windows Device Portal/Processes/Run command, "c:\windows\system32\bcdedit /set debug off")
+
 
 #### Data breakpoints have been disabled on the Raspberry Pi2
 No workaround at this time.

--- a/windows-iotcore/release-notes/Insider/17672.md
+++ b/windows-iotcore/release-notes/Insider/17672.md
@@ -64,9 +64,9 @@ The Raspberry Pi3 built-in Bluetooth driver only supports low bandwidth devices 
 
 #### Serial Port Usage and Access on RPi2 
 Raspberry Pi 2 supports the serial transport for communication through the PL011 UART.  This is set by default in kernel debugging scenarios.  An application or device driver can use the PL011 UART to send and receive data with the PL011 device driver turning off the debugger using the following command:
-```
-bcedit /set debug off 
-```
+`bcdedit /set debug off`
+(eg. In Windows Device Portal/Processes/Run command, "c:\windows\system32\bcdedit /set debug off")
+
 
 #### Data breakpoints have been disabled on the Raspberry Pi2
 No workaround at this time.

--- a/windows-iotcore/release-notes/Insider/17686.md
+++ b/windows-iotcore/release-notes/Insider/17686.md
@@ -67,9 +67,9 @@ The Raspberry Pi3 built-in Bluetooth driver only supports low bandwidth devices 
 
 #### Serial Port Usage and Access on RPi2 
 Raspberry Pi 2 supports the serial transport for communication through the PL011 UART.  This is set by default in kernel debugging scenarios.  An application or device driver can use the PL011 UART to send and receive data with the PL011 device driver turning off the debugger using the following command:
-```
-bcedit /set debug off 
-```
+`bcdedit /set debug off`
+(eg. In Windows Device Portal/Processes/Run command, "c:\windows\system32\bcdedit /set debug off")
+
 
 #### Data breakpoints have been disabled on the Raspberry Pi2
 No workaround at this time.

--- a/windows-iotcore/release-notes/Insider/17692.md
+++ b/windows-iotcore/release-notes/Insider/17692.md
@@ -70,9 +70,9 @@ The Raspberry Pi3 built-in Bluetooth driver only supports low bandwidth devices.
 
 #### Serial Port Usage and Access on RPi2 
 Raspberry Pi 2 supports the serial transport for communication through the PL011 UART.  This is set by default in kernel debugging scenarios.  An application or device driver can use the PL011 UART to send and receive data with the PL011 device driver turning off the debugger using the following command:
-```
-bcedit /set debug off 
-```
+`bcdedit /set debug off`
+(eg. In Windows Device Portal/Processes/Run command, "c:\windows\system32\bcdedit /set debug off")
+
 
 #### Data breakpoints have been disabled on the Raspberry Pi2
 No workaround at this time.


### PR DESCRIPTION
Fixed typo for incorrect command 'bcedit' to correct 'bcdedit'
