### PR TITLE
typo: teh -> the

### DIFF
--- a/windows-iotcore/manage-your-device/DevicePortal.md
+++ b/windows-iotcore/manage-your-device/DevicePortal.md
@@ -20,7 +20,7 @@ keywords: windows iot, Windows Device Portal, remote, device portal
 > Live kernel debug is currently failing for ARM devices. We are working to get this fixed.
 
 > [!IMPORTANT]
-> If you are building an open retail device for commercial deployment to a "specific/limited installation" (i.e. factory or retail store) where the end-user does the final configuration and you document your customers that they must [obtain a certificate for WDP and install it on both WDP and connecting browsers and passwords are changed on WDP](https://docs.microsoft.com/en-us/windows/uwp/debug-test-perf/device-portal-ssl), then using WDP in this narrow commercial instance is acceptable. Retail images in this scenario should still *not* include IOT_TOOLKIT, but should use teh IOT_WEBBEXTN package to pull in WDP. 
+> If you are building an open retail device for commercial deployment to a "specific/limited installation" (i.e. factory or retail store) where the end-user does the final configuration and you document your customers that they must [obtain a certificate for WDP and install it on both WDP and connecting browsers and passwords are changed on WDP](https://docs.microsoft.com/en-us/windows/uwp/debug-test-perf/device-portal-ssl), then using WDP in this narrow commercial instance is acceptable. Retail images in this scenario should still *not* include IOT_TOOLKIT, but should use the IOT_WEBBEXTN package to pull in WDP. 
 
 ## Shared Documentation
 WDP is a developer tool shared among all Windows 10 devices. Each product has its own unique features, but the core functionality is the same.


### PR DESCRIPTION
GitHub web editor decided the line endings where inconsistent and converted to CRLF. Might be good to add a `.gitattributes` files