### PR TITLE
Fix bad download link for IoT Core Dashboard

### DIFF
--- a/windows-iotcore/connect-your-device/IoTDashboard.md
+++ b/windows-iotcore/connect-your-device/IoTDashboard.md
@@ -12,7 +12,7 @@ keywords: windows iot, windows 10 iot core dashboard, windows iot dashboard, dev
 
 Windows 10 IoT Core Dashboard is the best way to download, set up and connect your Windows 10 IoT Core devices, all from your PC.
 
-You can download the [IoT Core Dashboard here](http://go.microsoft.com/fwlink/?LinkID=708576).
+You can download the [IoT Core Dashboard here](https://iottools.blob.core.windows.net/iotdashboard/Windows10IoTCoreDashboard.application).
 
 > [!NOTE]
 > If you're finding that you're getting a white screen when opening the IoT Dashboard after downloading, it may due to a driver issue. To overcome this issue, you'll need to download the [zip format](https://downloadmirror.intel.com/27894/a08/win64_24.20.100.6229.zip) of the Intel Graphics Driver and install the driver manually. 


### PR DESCRIPTION
Upon opening up the executable linked, you are currently greeted with: <br> `An error occurred attempting to install Windows 10IoTCoreDashboard.` 

![Screenshot (2)](https://user-images.githubusercontent.com/5903448/54963216-37cbd400-4f25-11e9-9edc-5805a9de7fd6.png)

I found the working link on a forum and the download and install worked fine.