### PR TITLE
double quote the string value if the value contains colon

### DIFF
--- a/windows-iotcore/TOC.yml
+++ b/windows-iotcore/TOC.yml
@@ -190,7 +190,7 @@
   items:
   - name: Insider previews
       items:
-      - name: Current: Build 17744
+      - name: "Current: Build 17744"
         href: release-notes/insider/17744.md
       - name: Build 17723
         href: release-notes/insider/17723.md
@@ -200,7 +200,7 @@
         href: release-notes/insider/17686.md
       - name: Build 17672
         href: release-notes/insider/17672.md
-      - name: Current: Build 17661
+      - name: "Current: Build 17661"
         href: release-notes/insider/17661.md
       - name: Raspberry Pi 3B+ release
         href: release-notes/insider/RPi3BP.md
@@ -216,7 +216,7 @@
         href: release-notes/insider/16257.md
   - name: Commercial releases
       items:
-      - name: Current: October 2018 Update (with January 2019 servicing)
+      - name: "Current: October 2018 Update (with January 2019 servicing)"
         href: release-notes/commercial/17763.md
       - name: October 2018 Update (Build 17763)
         href: release-notes/commercial/October2018Update.md


### PR DESCRIPTION
The colon in string value is not wrapped in double quote, which causes yaml parser failures and the ops build/publish [failures](https://opbuildstorageprod.blob.core.windows.net/report/2019/9/9/b7ad8aa9-a50c-8775-7946-7ff73befe148/Commit/201909090457125647-docs-build-v3/workflow_report.html?sv=2016-05-31&sr=b&sig=g1QFiGzJP7gsIHESDiQ4Z9%2F9n854kRdum0%2FhD6khsPg%3D&st=2019-09-09T04%3A54%3A08Z&se=2019-10-10T04%3A59%3A08Z&sp=r).