### PR TITLE
Style: remove duplicated key author in metadata

### DIFF
--- a/windows-iotcore/index.yml
+++ b/windows-iotcore/index.yml
@@ -4,7 +4,6 @@ title: Windows for IoT documentation
 summary: The Windows for IoT platform has multiple editions, each optimized for specific scenarios. They all share the security, manageability, support and cloud connectivity you expect from Window.
 
 metadata:
-  author: saraclay
   description: Learn about Windows for IoT for developing your own connected, embedded solutions.
   services: windows-iot
   ms.service: windows-iot


### PR DESCRIPTION
The key value pair `author: saraclay` has shown up more than once in `metadata`, this will cause yaml duplicate key warning in v3 build/publish.

We created this pull request to fix above issue and unblock v3 docfx migration 