### PR TITLE
Fixed Typo

### DIFF
--- a/windows-iotcore/tutorials/intel.md
+++ b/windows-iotcore/tutorials/intel.md
@@ -22,7 +22,7 @@ If you're looking to manufacture with a Qualcomm device, please refer to the [Io
 3. Create a USB-bootable WinPE image:
 4. Start the Deployment and Imaging Tools Environment `(C:\Program Files (x86)\Windows Kits\10\Assessment and Deployment Kit\Deployment Tools)` as an administrator.
 5. Create a working copy of the Windows PE files. Specify either x86, amd64 or ARM: `Copype amd64 C:\WINPE_amd64`
-6. Install Windows PE to the USB flash drive, specifying the WinPE drive letter below. More information can be found [here](https://docs.microsoft.com/windows-hardware/manufacture/desktop/winpe-create-usb-bootable-drive). `MMakeWinPEMedia /UFD C:\WinPE_amd64 P:`
+6. Install Windows PE to the USB flash drive, specifying the WinPE drive letter below. More information can be found [here](https://docs.microsoft.com/windows-hardware/manufacture/desktop/winpe-create-usb-bootable-drive). `MakeWinPEMedia /UFD C:\WinPE_amd64 P:`
 7. Download the [Windows 10 IoT Core image](https://downloads.up-community.org/?post_type=wpdmpro&p=204&preview=true) by double-clicking on the downloaded ISO file and locating the mounted Virtual CD-drive.
 8. This drive will contain an install file (.msi); double click it. This will create a new directory on your PC under C:\Program Files (x86)\Microsoft IoT\FFU\ in which you shoul d see an image file, "flash.ffu".
 9. Download, unzip and copy the [eMMC Installer script](https://github.com/ms-iot/content/blob/develop/Resources/eMMCInstaller.zip) to the USB device's root directory, along with the device's FFU.


### PR DESCRIPTION
Changed `MMakeWinPEMedia /UFD C:\WinPE_amd64` to `MakeWinPEMedia /UFD C:\WinPE_amd64`. The first M was extraneous. The actual command should have been `MakeWinPEMedia`.