### PR TITLE
Change "New-IoTDriverPackage" to "Add-IoTDriverPackage"

### DIFF
--- a/windows-iotcore/learn-about-hardware/PeripheralDrivers.md
+++ b/windows-iotcore/learn-about-hardware/PeripheralDrivers.md
@@ -28,7 +28,7 @@ The Step is to get the x86 version of the drivers from PC. For ARM, please conta
 ## Step 2: Create a driver package
 ___
 
-The Driver package contains the references(InfSource)to the Inf file for the driver and also lists all the files referenced in the Inf file. You can author the driver .wm.xml using [New-IoTDriverPackage](https://github.com/ms-iot/iot-adk-addonkit/tree/master/Tools/IoTCoreImaging/Docs/Add-IoTDriverPackage.md).
+The Driver package contains the references(InfSource)to the Inf file for the driver and also lists all the files referenced in the Inf file. You can author the driver .wm.xml using [Add-IoTDriverPackage](https://github.com/ms-iot/iot-adk-addonkit/tree/master/Tools/IoTCoreImaging/Docs/Add-IoTDriverPackage.md).
 
 [New-IoTInf2Cab](https://github.com/ms-iot/iot-adk-addonkit/tree/master/Tools/IoTCoreImaging/Docs/New-IoTInf2Cab.md) creates the package xml file and also builds the cab file directly.
 


### PR DESCRIPTION
Fixed the label on the link to Add-IoTDriverPackage as "New-IoTDriverPackage" does not exist and is confusing to those trying to create a CAB file for a third-party USB driver.