### PR TITLE
Removed processor support table 

### DIFF
--- a/windows-iotcore/windows-iot-enterprise.md
+++ b/windows-iotcore/windows-iot-enterprise.md
@@ -47,7 +47,7 @@ Specialized systems, such as PCs that control medical equipment, point-of-sale s
 
 ## Long-Term Support Silicon Details
 
-The Windows 10 IoT Enterprise 2019 release will be a LTSC release. The list below encompasses all processors expected to be supported for this release. If you are planning to use an earlier release of Windows 10 IoT Enterprise, you can find details on the processor support [here](https://docs.microsoft.com/windows-hardware/design/minimum/windows-processor-requirements#windows-iot-enterprise--embedded-processor-table).
+The Windows 10 IoT Enterprise 2019 release will be a LTSC release. See [here] (https://docs.microsoft.com/en-us/windows/whats-new/ltsc/) for a general description of Windows 10 LTSC and other channels available. You can find details on processor support for each edition and channel of Windows 10 [here](https://docs.microsoft.com/windows-hardware/design/minimum/windows-processor-requirements#windows-iot-enterprise--embedded-processor-table).
 
 ## Helpful resources
 > [!NOTE]

--- a/windows-iotcore/windows-iot-enterprise.md
+++ b/windows-iotcore/windows-iot-enterprise.md
@@ -49,26 +49,6 @@ Specialized systems, such as PCs that control medical equipment, point-of-sale s
 
 The Windows 10 IoT Enterprise 2019 release will be a LTSC release. The list below encompasses all processors expected to be supported for this release. If you are planning to use an earlier release of Windows 10 IoT Enterprise, you can find details on the processor support [here](https://docs.microsoft.com/windows-hardware/design/minimum/windows-processor-requirements#windows-iot-enterprise--embedded-processor-table).
 
-> | Windows 10 IoT Enterprise  |
-> |-------------|
-> | AMD® 6th Generation Processors Series Ax-8xxx & E-Series Ex-8xxx & FX-870K | 
-> | AMD® 7th Generation Processors Series Ax-9xxx & E-Series Ex-9xxx & FX-9xxx | 
-> | AMD® Ryzen™ 3/5/7 1xxx | 
-> | AMD® Ryzen™ 3/5/7 2xxx | 
-> | AMD® G-Series | 
-> | AMD® R-Series | 
-> | AMD® V1xxx | 
-> | 4th Generation Intel® Core™ Processors | 
-> | 5th Generation Intel® Core™ Processors |
-> | 6th Generation Intel® Core™ Processors |
-> | 7th Generation Intel® Core™ Processors |
-> | 8th Generation Intel® Core™ Processors |
-> | Intel® Atom™ processor E3900 series |
-> | Intel® Atom™ x5-E8000 Processor |
-> | Intel® Atom™ x5-Z8350 Processor |
-> | Intel® Atom™ Processor E3800 Product Family |
-> | Intel® Pentium® and Celeron® Processor N and J Series |
-
 ## Helpful resources
 > [!NOTE]
 > Additional resources may be available from your distributor to explain Windows EPKEA OEM Activation and provide guidance in generating your manufacturing-ready Windows IoT Enterprise [WIM](https://msdn.microsoft.com/library/windows/desktop/dd861280.aspx) device image.

--- a/windows-iotcore/windows-iot-enterprise.md
+++ b/windows-iotcore/windows-iot-enterprise.md
@@ -47,7 +47,7 @@ Specialized systems, such as PCs that control medical equipment, point-of-sale s
 
 ## Long-Term Support Silicon Details
 
-The Windows 10 IoT Enterprise 2019 release will be a LTSC release. See [here] (https://docs.microsoft.com/en-us/windows/whats-new/ltsc/) for a general description of Windows 10 LTSC and other channels available. You can find details on processor support for each edition and channel of Windows 10 [here](https://docs.microsoft.com/windows-hardware/design/minimum/windows-processor-requirements#windows-iot-enterprise--embedded-processor-table).
+The Windows 10 IoT Enterprise 2019 release will be a LTSC release. See [here](https://docs.microsoft.com/en-us/windows/whats-new/ltsc) for a general description of Windows 10 LTSC and other channels available. You can find details on processor support for each edition and channel of Windows 10 [here](https://docs.microsoft.com/windows-hardware/design/minimum/windows-processor-requirements#windows-iot-enterprise--embedded-processor-table).
 
 ## Helpful resources
 > [!NOTE]


### PR DESCRIPTION
Removed embedded table with supported processor info that was conflicting with the min processor requirements table and was causing customer confusion. 