### PR TITLE
Update toc.yml

### DIFF
--- a/windows-iotcore/breadcrumb/toc.yml
+++ b/windows-iotcore/breadcrumb/toc.yml
@@ -6,7 +6,7 @@
     tocHref: /windows/
     topicHref: /windows/
     items:
-      - name: Windows IoT Core documentation 
+      - name: Windows IoT Documentation 
         tocHref: /windows/iot-core/
         topicHref: "/windows/iot-core/index"  
         items:


### PR DESCRIPTION
No longer will say "Windows IoT Core Documentation" but instead "Windows IoT Documentation"